### PR TITLE
Overlapping pred fix

### DIFF
--- a/autovot/bin/auto_vot_decode.py
+++ b/autovot/bin/auto_vot_decode.py
@@ -235,27 +235,30 @@ if __name__ == "__main__":
         auto_vot_tier = tg.IntervalTier(name='AutoVOT', minTime=textgrid.minTime, maxTime=textgrid.maxTime)
         auto_vot_tier.add(textgrid.minTime, xmin_preds[0], '')
         # print textgrid.xmin(), xmin_preds[0], ''
-        for i in range(len(xmin_preds) - 1):
+        try:
+            for i in range(len(xmin_preds) - 1):
+                ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
+                # Check for overlapping predictions
+                if i > 0 and xmax_preds[i-1] > xmin_preds[i]:
+                    # In the case of overlapping, just put the min of next pred as the max of the previous
+                    auto_vot_tier.add(xmax_preds[i-1], xmax_preds[i], 'pred')
+                else:
+                    auto_vot_tier.add(xmin_preds[i], xmax_preds[i], 'pred')
+
+                # check for overlapping predictions
+                if not xmin_preds[i+1] < xmax_preds[i]:
+                    auto_vot_tier.add(xmax_preds[i], xmin_preds[i + 1], '')
             ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
-            # Check for overlapping predictions
-            if i > 0 and xmax_preds[i-1] > xmin_preds[i]:
-                # In the case of overlapping, just put the min of next pred as the max of the previous
-                auto_vot_tier.add(xmax_preds[i-1], xmax_preds[i], 'pred')
+
+            if xmax_preds[-2] > xmin_preds[-1]:
+                auto_vot_tier.add(xmax_preds[-2], xmax_preds[-1], 'pred')
             else:
-                auto_vot_tier.add(xmin_preds[i], xmax_preds[i], 'pred')
+                auto_vot_tier.add(xmin_preds[-1], xmax_preds[-1], 'pred')
 
-            # check for overlapping predictions
-            if not xmin_preds[i+1] < xmax_preds[i]:
-                auto_vot_tier.add(xmax_preds[i], xmin_preds[i + 1], '')
-        ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
-
-        if xmax_preds[-2] > xmin_preds[-1]:
-            auto_vot_tier.add(xmax_preds[-2], xmax_preds[-1], 'pred')
-        else:
-            auto_vot_tier.add(xmin_preds[-1], xmax_preds[-1], 'pred')
-
-        auto_vot_tier.add(xmax_preds[-1], textgrid.maxTime, '')
-
+            auto_vot_tier.add(xmax_preds[-1], textgrid.maxTime, '')
+        except ValueError as e:
+            logging.error("Overlapping stops detected, textgrid output stopped at {}".format(xmin_preds[i]))
+            
         ## check if target textgrid already has a tier named
         ## "AutoVOT", modulo preceding or trailing spaces or case. If
         ## so, action taken depends on if --ignore_existing_tiers flag

--- a/autovot/bin/auto_vot_decode.py
+++ b/autovot/bin/auto_vot_decode.py
@@ -234,27 +234,15 @@ if __name__ == "__main__":
         textgrid.read(textgrid_file)
         auto_vot_tier = tg.IntervalTier(name='AutoVOT', minTime=textgrid.minTime, maxTime=textgrid.maxTime)
         auto_vot_tier.add(textgrid.minTime, xmin_preds[0], '')
-        # print textgrid.xmin(), xmin_preds[0], ''
         try:
             for i in range(len(xmin_preds) - 1):
                 ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
-                # Check for overlapping predictions
-                if i > 0 and xmax_preds[i-1] > xmin_preds[i]:
-                    # In the case of overlapping, just put the min of next pred as the max of the previous
-                    auto_vot_tier.add(xmax_preds[i-1], xmax_preds[i], 'pred')
-                else:
-                    auto_vot_tier.add(xmin_preds[i], xmax_preds[i], 'pred')
+                auto_vot_tier.add(xmin_preds[i], xmax_preds[i], 'pred')
 
-                # check for overlapping predictions
-                if not xmin_preds[i+1] < xmax_preds[i]:
-                    auto_vot_tier.add(xmax_preds[i], xmin_preds[i + 1], '')
+                auto_vot_tier.add(xmax_preds[i], xmin_preds[i + 1], '')
             ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
 
-            if xmax_preds[-2] > xmin_preds[-1]:
-                auto_vot_tier.add(xmax_preds[-2], xmax_preds[-1], 'pred')
-            else:
-                auto_vot_tier.add(xmin_preds[-1], xmax_preds[-1], 'pred')
-
+            auto_vot_tier.add(xmin_preds[-1], xmax_preds[-1], 'pred')
             auto_vot_tier.add(xmax_preds[-1], textgrid.maxTime, '')
         except ValueError as e:
             logging.error("Overlapping stops detected, textgrid output stopped at {}".format(xmin_preds[i]))

--- a/autovot/bin/auto_vot_decode.py
+++ b/autovot/bin/auto_vot_decode.py
@@ -237,15 +237,24 @@ if __name__ == "__main__":
         # print textgrid.xmin(), xmin_preds[0], ''
         for i in range(len(xmin_preds) - 1):
             ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
-            auto_vot_tier.add(xmin_preds[i], xmax_preds[i], 'pred')
-            # print xmin_preds[i], xmax_preds[i], mark_preds[i]
-            auto_vot_tier.add(xmax_preds[i], xmin_preds[i + 1], '')
-            # print xmax_preds[i], xmin_preds[i+1], ''
+            # Check for overlapping predictions
+            if i > 0 and xmax_preds[i-1] > xmin_preds[i]:
+                # In the case of overlapping, just put the min of next pred as the max of the previous
+                auto_vot_tier.add(xmax_preds[i-1], xmax_preds[i], 'pred')
+            else:
+                auto_vot_tier.add(xmin_preds[i], xmax_preds[i], 'pred')
+
+            # check for overlapping predictions
+            if not xmin_preds[i+1] < xmax_preds[i]:
+                auto_vot_tier.add(xmax_preds[i], xmin_preds[i + 1], '')
         ## instead of mark_preds[i] (confidence number), just put 'pred' in the interval
-        auto_vot_tier.add(xmin_preds[-1], xmax_preds[-1], 'pred')
-        # print xmin_preds[-1], xmax_preds[-1], mark_preds[-1]
+
+        if xmax_preds[-2] > xmin_preds[-1]:
+            auto_vot_tier.add(xmax_preds[-2], xmax_preds[-1], 'pred')
+        else:
+            auto_vot_tier.add(xmin_preds[-1], xmax_preds[-1], 'pred')
+
         auto_vot_tier.add(xmax_preds[-1], textgrid.maxTime, '')
-        # print xmax_preds[-1], textgrid.xmax(), ''
 
         ## check if target textgrid already has a tier named
         ## "AutoVOT", modulo preceding or trailing spaces or case. If


### PR DESCRIPTION
This fixes #83.  It will just prevent the script from erroring out when overlapping predictions are found. It will output an error and then continue the script with the predictions that had worked up to this point.

Note: If the csv is still outputted, it will output all predictions, regardless of if they're overlapping. 